### PR TITLE
Updating to latest released version (1.0.1) of eforms-core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
     <!-- Versions - eForms -->
-    <version.eforms-core>1.0.0</version.eforms-core>
+    <version.eforms-core>1.0.1</version.eforms-core>
 
     <!-- Versions - Third-party libraries -->
     <version.xml.bind-api>2.3.3</version.xml.bind-api>


### PR DESCRIPTION
Updating to latest released version (1.0.1) of eforms-core as the previous one had trouble with already downloaded SDK folders.