### PR TITLE
Allowing SDK 1.6 in the editor demo

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,7 +21,7 @@ eforms:
     path: eforms-sdks
 
     # Comma-separated list of the supported major versions of eForms SDK
-    versions: 1.0,1.1,1.2,1.3,1.4,1.5 #,1.6
+    versions: 1.0,1.1,1.2,1.3,1.4,1.5,1.6
 
 
 proxy:


### PR DESCRIPTION
The SDK 1.6 has the namespaces which are needed for the XML generation sort order, this is important for the XSD validation.